### PR TITLE
hotfix for subscription init

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -59,6 +59,7 @@ export class ReduxLink extends ApolloLink {
     }
     else if (isSubscription(definition.operation)) {
       this.store.dispatch(subscriptionInit(operation));
+      return observer;
     }
     return observer.map(result => {
       if (isQuery(definition.operation)) {


### PR DESCRIPTION
Great package, btw!

The observer from `forward(operation)` for subscription inits using `apollo-link-ws` is for some reason an Object and not an Observable with a `map` function, so currently breaking otherwise. 

`observer.map is not a function`

This seemed to fix :)